### PR TITLE
Accept cache store limit as argument

### DIFF
--- a/fitz.go
+++ b/fitz.go
@@ -34,6 +34,12 @@ var (
 	ErrLoadOutline   = errors.New("fitz: cannot load outline")
 )
 
+// Cache limits.
+const (
+	StoreUnlimited = C.FZ_STORE_UNLIMITED
+	StoreDefault = C.FZ_STORE_DEFAULT
+)
+
 // Document represents fitz document.
 type Document struct {
 	ctx *C.struct_fz_context
@@ -58,6 +64,11 @@ type Outline struct {
 
 // New returns new fitz document.
 func New(filename string) (f *Document, err error) {
+	return NewWithStoreLimit(filename, StoreUnlimited)
+}
+
+// NewWithStoreLimit returns new fitz document with limit in the size of the resource store.
+func NewWithStoreLimit(filename string, maxStore uint64) (f *Document, err error) {
 	f = &Document{}
 
 	filename, err = filepath.Abs(filename)
@@ -70,7 +81,7 @@ func New(filename string) (f *Document, err error) {
 		return
 	}
 
-	f.ctx = (*C.struct_fz_context)(unsafe.Pointer(C.fz_new_context_imp(nil, nil, C.FZ_STORE_UNLIMITED, C.fz_version)))
+	f.ctx = (*C.struct_fz_context)(unsafe.Pointer(C.fz_new_context_imp(nil, nil, C.ulong(maxStore), C.fz_version)))
 	if f.ctx == nil {
 		err = ErrCreateContext
 		return
@@ -97,9 +108,14 @@ func New(filename string) (f *Document, err error) {
 
 // NewFromMemory returns new fitz document from byte slice.
 func NewFromMemory(b []byte) (f *Document, err error) {
+	return NewFromMemoryWithStoreLimit(b, StoreUnlimited)
+}
+
+// NewFromMemory returns new fitz document from byte slice with limit in the size of the resource store.
+func NewFromMemoryWithStoreLimit(b []byte, maxStore uint64) (f *Document, err error) {
 	f = &Document{}
 
-	f.ctx = (*C.struct_fz_context)(unsafe.Pointer(C.fz_new_context_imp(nil, nil, C.FZ_STORE_UNLIMITED, C.fz_version)))
+	f.ctx = (*C.struct_fz_context)(unsafe.Pointer(C.fz_new_context_imp(nil, nil, C.ulong(maxStore), C.fz_version)))
 	if f.ctx == nil {
 		err = ErrCreateContext
 		return
@@ -133,13 +149,18 @@ func NewFromMemory(b []byte) (f *Document, err error) {
 
 // NewFromReader returns new fitz document from io.Reader.
 func NewFromReader(r io.Reader) (f *Document, err error) {
+	return NewFromReaderWithStoreLimit(r, StoreUnlimited)
+}
+
+// NewFromReader returns new fitz document from io.Reader with limit in the size of the resource store.
+func NewFromReaderWithStoreLimit(r io.Reader, maxStore uint64) (f *Document, err error) {
 	b, e := ioutil.ReadAll(r)
 	if e != nil {
 		err = e
 		return
 	}
 
-	f, err = NewFromMemory(b)
+	f, err = NewFromMemoryWithStoreLimit(b, maxStore)
 
 	return
 }


### PR DESCRIPTION
@openrm/dev 

There was a hard-coded parameter passed when it initializes a `fz_context` that was possibly causing the cache to grow infinitely upon usage.
Please note, though, that the limit specified here is only a "soft" limit that may be exceeded.

https://www.mupdf.com/docs/api/core.html

https://github.com/ArtifexSoftware/mupdf/blob/02c34908c99abca515b3e21f4736007d12991629/include/mupdf/fitz/context.h#L125-L137